### PR TITLE
Profile -> collection

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -403,7 +403,7 @@ out in the same tree and use relative links so that they'll work offline,
           organizational identities and their associated data. 
         </p>
         <p>
-          Collection membership is not exclusive; e.g. a credential representing
+          Collection membership is not exclusive; e.g., a credential representing
           college graduation could appear in a "student record" collection as well 
           as a "professional profile" collection.  
         </p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -403,9 +403,9 @@ out in the same tree and use relative links so that they'll work offline,
           organizational identities and their associated data. 
         </p>
         <p>
-          Collection membership is not exclusive; e.g., a credential representing
-          college graduation could appear in a "student record" collection as well 
-          as a "professional profile" collection.  
+          Collection membership is not exclusive; for instance, a credential
+          representing college graduation could appear in a "student record"
+          collection as well as a "professional profile" collection.
         </p>
 
         <p>Here is an example of a professional profile collection.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -320,8 +320,8 @@ out in the same tree and use relative links so that they'll work offline,
           <a>wallet</a>. MAY support <a>transfer</a>,<a>issue</a>, <a>prove</a>.
         </dd>
 
-        <dt><dfn>profile</dfn></dt>
-        <dd>A profile is a named bucket for grouping wallet content.</dd>
+        <dt><dfn>collection</dfn></dt>
+        <dd>A collection is a named bucket for grouping wallet content.</dd>
 
         <dt><dfn>entropy</dfn></dt>
         <dd>
@@ -392,22 +392,27 @@ out in the same tree and use relative links so that they'll work offline,
       </p>
 
       <section>
-        <h3 id="Profile">Profile</h3>
+        <h3 id="Collection">Collection</h3>
 
-        <p>A profile is a named bucket for grouping wallet content.</p>
+        <p>A collection is a named bucket for grouping wallet content.</p>
         <p>
-          A profile MAY be used to group all correlatable wallet items together.
+          A collection MAY be used to group all correlatable wallet items together.
         </p>
         <p>
-          A profile MAY be used to manage separate external personal, or
-          organizational identities and their associated data.
+          A collection MAY be used to aggregate personal or
+          organizational identities and their associated data. 
+        </p>
+        <p>
+          Collection membership is not exclusive; e.g. a credential representing
+          college graduation could appear in a "student record" collection as well 
+          as a "professional profile" collection.  
         </p>
 
-        <p>Here is an example of a personal profile.</p>
+        <p>Here is an example of a professional profile collection.</p>
 
         <pre
           class="example highlight"
-          title="A profile for a personal identity"
+          title="A professional profile collection"
         >
 {
   "@context": ["https://w3id.org/wallet/v1"],
@@ -426,7 +431,7 @@ out in the same tree and use relative links so that they'll work offline,
 
         <pre
           class="example highlight"
-          title="A profile for an organizational identity"
+          title="An organizational identity collection"
         >
 {
   "@context": ["https://w3id.org/wallet/v1"],


### PR DESCRIPTION
Rename profile to collection and add some clarifications. Just a first pass to throw stones at.

Note that I retained/repurposed the word "profile" only for informal use in the example of a "professional profile", which seemed the best way to capture everyone's mental model (e.g. "LinkedIn Profile").

Was on the fence about whether to include the following elements from the discussion in #47, but decided it was _probably_ unnecessary. 

1. Additional clarifying examples:

| Number | Collection  | Collection name | Description of Collection / "Profile" | 
|---| ---|---|----|
| 1 | credentials issued by issuer A | "Issuer A" | Information about issuer A (type `Organization`) |
| 2 | Credentials related to my work history | "Kim's Verifiable Work Record" | Information about me (type `Person`) |  
| 3 | all issuers/orgs that have issued me credentials | "My Issuers" | maybe some wallet-generated metadata | 

2. Clarifying that collection contents may also be populated dynamically (by facet, tag, whatever).