### PR TITLE
forgot example styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1127,7 +1127,7 @@ out in the same tree and use relative links so that they'll work offline,
         <p>
 Here is an example of using Meta Data to reference non-standard data: 
         </p>
-        <pre>
+        <pre class="example highlight" title="An example of meta data referencing non-standard data">
 {
   "@context": ["https://w3id.org/wallet/v1"],
   "id": "urn:uuid:1d52bc38-c336-455a-8227-2c1e635df2d7",


### PR DESCRIPTION
Forgot to add styling to make meta data example appear as an "example" when rendered