### PR TITLE
Rename "CustomData" in example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1131,7 +1131,7 @@ Here is an example of using Meta Data to reference non-standard data:
 {
   "@context": ["https://w3id.org/wallet/v1"],
   "id": "urn:uuid:1d52bc38-c336-455a-8227-2c1e635df2d7",
-  "type": "CustomData",
+  "type": "MyCustomDataType",
   "name": "Quantum Computing 101",
   "image": "https://via.placeholder.com/150",
   "description" : "Certificate of completion from an online quantum computing course",


### PR DESCRIPTION
Renamed "CustomData" to "MyCustomDataType" because of reported confusion about whether this is a first-class type the wallet understands. This is meant to clarify that implementors should define their own type; the universal wallet does not have a general non-standard data type.