### PR TITLE
Fix Notation regarding ECC key descriptions and object structures 

### DIFF
--- a/docs/data-model.html
+++ b/docs/data-model.html
@@ -102,8 +102,8 @@
         "type": "JsonWebKey2020",
         "controller": "did:key:z6Mks8mvCnVx4HQcoq7ZwvpTbMnoRGudHSiEpXhMf6VW8XMg",
         "publicKeyJwk": {
-          "crv": "Ed25519",
-          "x": "vGur-MEOrN6GDLf4TBGHDYAERxkmWOjTbztvG3xP0I8",
+          "crv": "Edwards25519",
+          "y": "vGur-MEOrN6GDLf4TBGHDYAERxkmWOjTbztvG3xP0I8",
           "kty": "OKP"
         }
       },
@@ -466,15 +466,15 @@
   "controller": "did:example:123",
   "type": "Ed25519VerificationKey2018",
   "publicKeyJwk": {
-    "crv": "Ed25519",
-    "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+    "crv": "Edwards25519",
+    "y": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
     "kty": "OKP",
     "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
   },
   "privateKeyJwk": {
-    "crv": "Ed25519",
-    "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
-    "d": "tP7VWE16yMQWUO2G250yvoevfbfxY25GjHglTP3ZOyU",
+    "crv": "Edwards25519",
+    "y": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+    "k": "tP7VWE16yMQWUO2G250yvoevfbfxY25GjHglTP3ZOyU",
     "kty": "OKP",
     "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
   }
@@ -515,8 +515,8 @@
   "controller": "did:key:z6MkjjCpsoQrwnEmqHzLdxWowXk5gjbwor4urC1RPDmGeV8r",
   "type": "Ed25519VerificationKey2018",
   "publicKeyJwk": {
-    "crv": "Ed25519",
-    "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+    "crv": "Edwards25519",
+    "y": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
     "kty": "OKP",
     "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
   },
@@ -539,8 +539,8 @@
   "controller": "did:key:z6MkjjCpsoQrwnEmqHzLdxWowXk5gjbwor4urC1RPDmGeV8r",
   "type": "Ed25519VerificationKey2018",
   "publicKeyJwk": {
-    "crv": "Ed25519",
-    "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+    "crv": "Edwards25519",
+    "y": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
     "kty": "OKP",
     "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
   },


### PR DESCRIPTION
# Why

Some of the notations are incorrect in the context of elliptic curve cryptography specifically in the context of Twisted Edwards Curve form. 

- **Private key notation change**: from **d** to **k**; because **d** is a throw back to RSA private key notation; **k** is used commonly to represent the scalar value [ECC private key]

- The **crv** field stated `ed25519` which is a signature scheme **NOT** a curve, the curve is called `Edwards25519`

- Assuming the spec intends to hold the public key coordinate inside the private key declaration, it should be represented as `y`, unlike Montgomery form curves (i.e Curve25519), which use the `x` coordinate with a `y` sign bit in compressed form, the Edward's twist uses a `y` coordinate with an `x` sign bit. 

## References

- [Curve25519] (https://crypto.stackexchange.com/questions/72134/raw-curve25519-public-key-points)
- [Crypto Curves] (https://safecurves.cr.yp.to/equation.html)
- [Edwards Curves] (https://cryptobook.nakov.com/asymmetric-key-ciphers/elliptic-curve-cryptography-ecc#edwards-curves)
